### PR TITLE
Added installation requirements to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Our address is: Spatie, Samberstraat 69D, 2060 Antwerp, Belgium.
 
 The best postcards will get published on the open source page on our website.
 
+## Requirements
+This package requires PHP 7 or newer.
+
 ## Installation
 
 You can install the package via composer:


### PR DESCRIPTION
Added system requirement to the README.md.
This project needs PHP 7, specifying the requirements will save users the headache of installing on a earlier version of PHP just to find out that it's incompatible.