### PR TITLE
Support nested translations

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -27,19 +27,28 @@ class LanguageLine extends Model
         });
     }
 
+    /**
+     * Get translations for group
+     *
+     * @param string $locale
+     * @param string $group
+     *
+     * @return array
+     * @see https://adamwathan.me/2016/07/14/customizing-keys-when-mapping-collections/
+     */
     public static function getTranslationsForGroup(string $locale, string $group): array
     {
         return Cache::rememberForever(static::getCacheKey($group, $locale), function () use ($group, $locale) {
-            $translations = [];
-
-            static::query()
+            $lines = static::query()
                 ->where('group', $group)
                 ->get()
-                ->map(function (LanguageLine $languageLine) use ($locale, &$translations) {
-                    array_set($translations, $languageLine->key, $languageLine->getTranslation($locale));
+                ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
+                    array_set($lines, $languageLine->key, $languageLine->getTranslation($locale));
+
+                    return $lines;
                 });
 
-            return $translations;
+            return $lines ?? [];
         });
     }
 

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -39,16 +39,14 @@ class LanguageLine extends Model
     public static function getTranslationsForGroup(string $locale, string $group): array
     {
         return Cache::rememberForever(static::getCacheKey($group, $locale), function () use ($group, $locale) {
-            $lines = static::query()
+            return static::query()
                 ->where('group', $group)
                 ->get()
                 ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
                     array_set($lines, $languageLine->key, $languageLine->getTranslation($locale));
 
                     return $lines;
-                });
-
-            return $lines ?? [];
+                }) ?? [];
         });
     }
 

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -30,7 +30,7 @@ class LanguageLine extends Model
     public static function getTranslationsForGroup(string $locale, string $group): array
     {
         return Cache::rememberForever(static::getCacheKey($group, $locale), function () use ($group, $locale) {
-            return static::query()
+            $languageLines = static::query()
                 ->where('group', $group)
                 ->get()
                 ->map(function (LanguageLine $languageLine) use ($locale) {
@@ -41,6 +41,13 @@ class LanguageLine extends Model
                 })
                 ->pluck('text', 'key')
                 ->toArray();
+
+            $result = [];
+            foreach ($languageLines as $key => $value) {
+                array_set($result, $key, $value);
+            }
+
+            return $result;
         });
     }
 

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -30,24 +30,16 @@ class LanguageLine extends Model
     public static function getTranslationsForGroup(string $locale, string $group): array
     {
         return Cache::rememberForever(static::getCacheKey($group, $locale), function () use ($group, $locale) {
-            $languageLines = static::query()
+            $translations = [];
+
+            static::query()
                 ->where('group', $group)
                 ->get()
-                ->map(function (LanguageLine $languageLine) use ($locale) {
-                    return [
-                        'key' => $languageLine->key,
-                        'text' => $languageLine->getTranslation($locale),
-                    ];
-                })
-                ->pluck('text', 'key')
-                ->toArray();
+                ->map(function (LanguageLine $languageLine) use ($locale, $group, &$translations) {
+                    array_set($translations, $languageLine->key, $languageLine->getTranslation($locale));
+                });
 
-            $result = [];
-            foreach ($languageLines as $key => $value) {
-                array_set($result, $key, $value);
-            }
-
-            return $result;
+            return $translations;
         });
     }
 

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -35,7 +35,7 @@ class LanguageLine extends Model
             static::query()
                 ->where('group', $group)
                 ->get()
-                ->map(function (LanguageLine $languageLine) use ($locale, $group, &$translations) {
+                ->map(function (LanguageLine $languageLine) use ($locale, &$translations) {
                     array_set($translations, $languageLine->key, $languageLine->getTranslation($locale));
                 });
 

--- a/tests/TransTest.php
+++ b/tests/TransTest.php
@@ -4,6 +4,13 @@ namespace Spatie\TranslationLoader\Test;
 
 class TransTest extends TestCase
 {
+    private $nested = [
+        'bool' => [
+            1 => 'Yes',
+            0 => 'No',
+        ]
+    ];
+
     public function setUp()
     {
         parent::setUp();
@@ -29,5 +36,37 @@ class TransTest extends TestCase
         $this->createLanguageLine('file', 'key', ['en' => 'en value from db']);
 
         $this->assertEquals('en value from db', trans('file.key'));
+    }
+
+    /** @test */
+    public function it_will_return_array_if_its_nested_translation()
+    {
+        foreach (array_dot($this->nested) as $key => $text) {
+            $this->createLanguageLine('nested', $key, ['en' => $text]);
+        }
+
+        $this->assertEquals($this->nested['bool'], trans('nested.bool'), "\$canonicalize = true", $delta = 0.0, $maxDepth = 10, $canonicalize = true);
+    }
+
+    /** @test */
+    public function it_will_return_translation_if_max_nested_level_is_reached()
+    {
+        foreach (array_dot($this->nested) as $key => $text) {
+            $this->createLanguageLine('nested', $key, ['en' => $text]);
+        }
+
+        $this->assertEquals($this->nested['bool'][1], trans('nested.bool.1'));
+    }
+
+    /** @test */
+    public function it_will_return_translation_key_if_not_found()
+    {
+        $notFoundKey = 'nested.bool.3';
+
+        foreach (array_dot($this->nested) as $key => $text) {
+            $this->createLanguageLine('nested', $key, ['en' => $text]);
+        }
+
+        $this->assertEquals($notFoundKey, trans($notFoundKey));
     }
 }


### PR DESCRIPTION
Conver the result array from dot notation to a multidimentional array to be abe to have nested translations like: 
general.bool.1 => 'Yes'
general.bool.0 => 'No'

and if accessed like so: 
```
trans('general.bool')
```
will get:
```
array:2 [
  1 => "Yes"
  0 => "No"
]
```

Usefull for example when using Laravel Collective Html packeage and passing translation as a select options key/value pairs like so:
```
{!! Form::select('is_active', trans('general.bool'), null) !!}
```

Think it's the same requested at #24 

Regards

Nasko