### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/container": "~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/contracts": "~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev",
-        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev"
+        "illuminate/container": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/contracts": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
-        "orchestra/database": "~3.3.0|~3.4.0|~3.5.x-dev"
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev",
+        "orchestra/database": "~3.3.0|~3.4.0|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -57,3 +57,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/container": "~5.3.0|~5.4.0",
-        "illuminate/contracts": "~5.3.0|~5.4.0",
-        "illuminate/database": "~5.3.0|~5.4.0",
-        "illuminate/support": "~5.3.0|~5.4.0"
+        "illuminate/container": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/contracts": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/database": "~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.3.0|~5.4.0|~5.5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench":  "~3.3.0|~3.4.0",
-        "orchestra/database":  "~3.3.0|~3.4.0"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "~3.3.0|~3.4.0|~3.5.x-dev",
+        "orchestra/database": "~3.3.0|~3.4.0|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-translation-loader/phpunit.xml.dist

.....................                                             21 / 21 (100%)

Time: 7.46 seconds, Memory: 18.00MB

OK (21 tests, 26 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments