### PR TITLE
Handle numeric keys

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -26,7 +26,7 @@ class TranslationLoaderManager extends FileLoader
 
         $loaderTranslations = $this->getTranslationsForTranslationLoaders($locale, $group, $namespace);
 
-        return array_merge($fileTranslations, $loaderTranslations);
+        return $loaderTranslations + $fileTranslations;
     }
 
     protected function getTranslationsForTranslationLoaders(
@@ -38,7 +38,7 @@ class TranslationLoaderManager extends FileLoader
             ->map(function (string $className) {
                 return app($className);
             })
-            ->flatMap(function (TranslationLoader $translationLoader) use ($locale, $group, $namespace) {
+            ->mapWithKeys(function (TranslationLoader $translationLoader) use ($locale, $group, $namespace) {
                 return $translationLoader->loadTranslations($locale, $group, $namespace);
             })
             ->toArray();

--- a/tests/TransTest.php
+++ b/tests/TransTest.php
@@ -20,6 +20,7 @@ class TransTest extends TestCase
     public function it_can_get_translations_for_language_files()
     {
         $this->assertEquals('en value', trans('file.key'));
+        $this->assertEquals('page not found', trans('file.404.title'));
     }
 
     /** @test */
@@ -28,14 +29,17 @@ class TransTest extends TestCase
         app()->setLocale('nl');
 
         $this->assertEquals('nl value', trans('file.key'));
+        $this->assertEquals('pagina niet gevonden', trans('file.404.title'));
     }
 
     /** @test */
     public function by_default_it_will_prefer_a_db_translation_over_a_file_translation()
     {
         $this->createLanguageLine('file', 'key', ['en' => 'en value from db']);
+        $this->createLanguageLine('file', '404.title', ['en' => 'page not found from db']);
 
         $this->assertEquals('en value from db', trans('file.key'));
+        $this->assertEquals('page not found from db', trans('file.404.title'));
     }
 
     /** @test */

--- a/tests/fixtures/lang/en/file.php
+++ b/tests/fixtures/lang/en/file.php
@@ -2,4 +2,7 @@
 
 return [
     'key' => 'en value',
+    '404' => [
+        'title' => 'page not found',
+    ],
 ];

--- a/tests/fixtures/lang/nl/file.php
+++ b/tests/fixtures/lang/nl/file.php
@@ -2,4 +2,7 @@
 
 return [
     'key' => 'nl value',
+    '404' => [
+        'title'   => 'pagina niet gevonden',
+    ],
 ];


### PR DESCRIPTION
Laravel default translator can handle numeric keys, so this should be too.