### PR TITLE
Allow to configure and override TranslationLoaderManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ This is the contents of the published config file:
 return [
 
     /*
+     * This is the translation manager which overrides the default Laravel `translation.loader`
+     */
+    'translation_manager' => Spatie\TranslationLoader\TranslationLoaderManager::class,
+    
+    /*
      * Language lines will be fetched by these loaders. You can put any class here that implements
      * the Spatie\TranslationLoader\TranslationLoaders\TranslationLoader-interface.
      */

--- a/config/translation-loader.php
+++ b/config/translation-loader.php
@@ -3,6 +3,11 @@
 return [
 
     /*
+     * This is the translation manager which overrides the default Laravel `translation.loader`
+     */
+    'translation_manager' => Spatie\TranslationLoader\TranslationLoaderManager::class,
+
+    /*
      * Language lines will be fetched by these loaders. You can put any class here that implements
      * the Spatie\TranslationLoader\TranslationLoaders\TranslationLoader-interface.
      */

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -46,6 +46,7 @@ class TranslationServiceProvider extends IlluminateTranslationServiceProvider
     {
         $this->app->singleton('translation.loader', function ($app) {
             $class = config('translation-loader.translation_manager');
+
             return new $class($app['files'], $app['path.lang']);
         });
     }

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -45,7 +45,8 @@ class TranslationServiceProvider extends IlluminateTranslationServiceProvider
     protected function registerLoader()
     {
         $this->app->singleton('translation.loader', function ($app) {
-            return new TranslationLoaderManager($app['files'], $app['path.lang']);
+            $class = config('translation-loader.translation_manager');
+            return new $class($app['files'], $app['path.lang']);
         });
     }
 }

--- a/tests/DummyManagerTest.php
+++ b/tests/DummyManagerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\TranslationLoader\Test;
+
+use Spatie\TranslationLoader\Test\TranslationManagers\DummyManager;
+
+class DummyManagerTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('translation-loader.translation_manager', DummyManager::class);
+    }
+
+    /** @test */
+    public function it_allow_to_change_translation_manager()
+    {
+        $this->assertInstanceOf(DummyManager::class, $this->app['translation.loader']);
+    }
+
+    /** @test */
+    public function it_can_translate_using_dummy_manager_using_file()
+    {
+        $this->assertEquals('en value', trans('file.key'));
+    }
+
+    /** @test */
+    public function it_can_translate_using_dummy_manager_using_db()
+    {
+        $this->createLanguageLine('file', 'key', ['en' => 'en value from db']);
+        $this->assertEquals('en value from db', trans('file.key'));
+    }
+}

--- a/tests/TranslationManagers/DummyManager.php
+++ b/tests/TranslationManagers/DummyManager.php
@@ -6,5 +6,4 @@ use Spatie\TranslationLoader\TranslationLoaderManager;
 
 class DummyManager extends TranslationLoaderManager
 {
-
 }

--- a/tests/TranslationManagers/DummyManager.php
+++ b/tests/TranslationManagers/DummyManager.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\TranslationLoader\Test\TranslationManagers;
+
+use Spatie\TranslationLoader\TranslationLoaderManager;
+
+class DummyManager extends TranslationLoaderManager
+{
+
+}


### PR DESCRIPTION
This PR allows us to _override_ the `TranslationLoaderManager` using the config file.

Tests are provided.