### PR TITLE
Fix missing keys

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -26,7 +26,7 @@ class TranslationLoaderManager extends FileLoader
 
         $loaderTranslations = $this->getTranslationsForTranslationLoaders($locale, $group, $namespace);
 
-        return $loaderTranslations + $fileTranslations;
+        return array_replace_recursive($fileTranslations, $loaderTranslations);
     }
 
     protected function getTranslationsForTranslationLoaders(

--- a/tests/TransTest.php
+++ b/tests/TransTest.php
@@ -21,6 +21,7 @@ class TransTest extends TestCase
     {
         $this->assertEquals('en value', trans('file.key'));
         $this->assertEquals('page not found', trans('file.404.title'));
+        $this->assertEquals('This page does not exists', trans('file.404.message'));
     }
 
     /** @test */
@@ -30,6 +31,7 @@ class TransTest extends TestCase
 
         $this->assertEquals('nl value', trans('file.key'));
         $this->assertEquals('pagina niet gevonden', trans('file.404.title'));
+        $this->assertEquals('Deze pagina bestaat niet', trans('file.404.message'));
     }
 
     /** @test */
@@ -40,6 +42,7 @@ class TransTest extends TestCase
 
         $this->assertEquals('en value from db', trans('file.key'));
         $this->assertEquals('page not found from db', trans('file.404.title'));
+        $this->assertEquals('This page does not exists', trans('file.404.message'));
     }
 
     /** @test */

--- a/tests/fixtures/lang/en/file.php
+++ b/tests/fixtures/lang/en/file.php
@@ -4,5 +4,6 @@ return [
     'key' => 'en value',
     '404' => [
         'title' => 'page not found',
+        'message' => 'This page does not exists',
     ],
 ];

--- a/tests/fixtures/lang/nl/file.php
+++ b/tests/fixtures/lang/nl/file.php
@@ -4,5 +4,6 @@ return [
     'key' => 'nl value',
     '404' => [
         'title'   => 'pagina niet gevonden',
+        'message' => 'Deze pagina bestaat niet',
     ],
 ];


### PR DESCRIPTION
Hey there,

this PR fix an issue where array merge is not correct.

The issue is the following
```php
# dummy.php
return [
      'foo' => [
           'bar' => 'hello',
           'hey' => 'ho',
     ]
];

LanguageLine::create([
   'group' => 'dummy',
   'key' => 'foo.bar',
   'text' => ['en' => 'Hello world'],
]);

trans('dummy.foo.bar'); // Hello world
trans('dummy.foo.hey'); // dummy.foo.hey
```
