### PR TITLE
Fixed not using fallbacak_locale setting when the DB loader is used.

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -53,7 +53,7 @@ class LanguageLine extends Model
      */
     public function getTranslation(string $locale): string
     {
-        return $this->text[$locale] ?? '';
+        return $this->text[$locale] ?? $this->text[config('app.fallback_locale')];
     }
 
     /**

--- a/tests/TransTest.php
+++ b/tests/TransTest.php
@@ -76,4 +76,13 @@ class TransTest extends TestCase
 
         $this->assertEquals($notFoundKey, trans($notFoundKey));
     }
+
+    /** @test */
+    public function it_will_default_to_fallback_if_locale_is_missing()
+    {
+        app()->setLocale('de');
+        $this->createLanguageLine('missing_locale', 'key', ['en' => 'en value from db']);
+
+        $this->assertEquals('en value from db', trans('missing_locale.key'));
+    }
 }


### PR DESCRIPTION
Hey, 

this is a fix for #51. 

I added a failing test and it looks like that the problem is fixed. 

However I don't know where you stand on using `config()` to get the fallback locale inside the `LanguageLine` model. 

Please let me know if additional tests or changes are needed! 