### PR TITLE
Fix fallback locale not working issue

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -34,12 +34,11 @@ class LanguageLine extends Model
                 ->where('group', $group)
                 ->get()
                 ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
-                    if (!empty($languageLine->getTranslation($locale))) {
+                    if (! empty($languageLine->getTranslation($locale))) {
                         array_set($lines, $languageLine->key, $languageLine->getTranslation($locale));
 
                         return $lines;
                     }
-                    return null;
                 }) ?? [];
         });
     }

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -34,9 +34,12 @@ class LanguageLine extends Model
                 ->where('group', $group)
                 ->get()
                 ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
-                    array_set($lines, $languageLine->key, $languageLine->getTranslation($locale));
+                    if (!empty($languageLine->getTranslation($locale))) {
+                        array_set($lines, $languageLine->key, $languageLine->getTranslation($locale));
 
-                    return $lines;
+                        return $lines;
+                    }
+                    return null;
                 }) ?? [];
         });
     }

--- a/tests/TransTest.php
+++ b/tests/TransTest.php
@@ -76,4 +76,14 @@ class TransTest extends TestCase
 
         $this->assertEquals($notFoundKey, trans($notFoundKey));
     }
+
+    /** @test */
+    public function it_will_return_fallback_language_translation_when_app_language_translation_not_available()
+    {
+        $this->createLanguageLine('fallback', 'key', ['en' => 'en value from db']);
+
+        app()->setLocale('pt-br');
+
+        $this->assertEquals('en value from db', trans('fallback.key'));
+    }
 }


### PR DESCRIPTION
Here is a fix for issue #51 
It will now return an empty array when no translation is available for the application language. That's what the Laravel translator expects, so it can handle the fallback locale.