### PR TITLE
Error when getting not existed translation

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -53,11 +53,11 @@ class LanguageLine extends Model
      */
     public function getTranslation(string $locale): string
     {
-        if(isset($this->text[$locale]) && !is_array($this->text[$locale])) {
+        if(isset($this->text[$locale])) {
             return $this->text[$locale];
         }
         $fallback = config('app.fallback_locale');
-        if(isset($this->text[$fallback]) && !is_array($this->text[$fallback])) {
+        if(isset($this->text[$fallback])) {
             return $this->text[$fallback];
         }
         return '';

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -53,10 +53,13 @@ class LanguageLine extends Model
      */
     public function getTranslation(string $locale): string
     {
-        if(isset($this->text[$locale]) && !is_array($this->text[$locale]))
+        if(isset($this->text[$locale]) && !is_array($this->text[$locale])) {
             return $this->text[$locale];
-        if(isset($this->text[config('app.fallback_locale')]) && !is_array($this->text[config('app.fallback_locale')]))
-            return $this->text[config('app.fallback_locale')];
+        }
+        $fallback = config('app.fallback_locale');
+        if(isset($this->text[$fallback]) && !is_array($this->text[$fallback])) {
+            return $this->text[$fallback];
+        }
         return '';
     }
 

--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -53,7 +53,11 @@ class LanguageLine extends Model
      */
     public function getTranslation(string $locale): string
     {
-        return $this->text[$locale] ?? $this->text[config('app.fallback_locale')];
+        if(isset($this->text[$locale]) && !is_array($this->text[$locale]))
+            return $this->text[$locale];
+        if(isset($this->text[config('app.fallback_locale')]) && !is_array($this->text[config('app.fallback_locale')]))
+            return $this->text[config('app.fallback_locale')];
+        return '';
     }
 
     /**

--- a/tests/LanguageLineTest.php
+++ b/tests/LanguageLineTest.php
@@ -50,14 +50,4 @@ class LanguageLineTest extends TestCase
         $this->assertEquals('English', $languageLine->getTranslation('es'));
     }
 
-    /** @test */
-    public function dont_return_arrays_if_was_set()
-    {
-        $value = [
-            'max' => 'Maximo',
-            'min' => 'Minimo'
-        ];
-        $languageLine = $this->createLanguageLine('validation', 'attributes', ['es' => $value]);
-        $this->assertEquals('', $languageLine->getTranslation('es'));
-    }
 }

--- a/tests/LanguageLineTest.php
+++ b/tests/LanguageLineTest.php
@@ -35,4 +35,29 @@ class LanguageLineTest extends TestCase
 
         $this->assertEquals('nederlands', $languageLine->getTranslation('nl'));
     }
+
+    /** @test */
+    public function it_doesnt_show_error_when_getting_unnexisted_translation()
+    {
+        $languageLine = $this->createLanguageLine('group', 'new', ['nl' => 'nederlands']);
+        $this->assertEquals('', $languageLine->getTranslation('en'));
+    }
+
+    /** @test */
+    public function get_fallback_locale_if_doesnt_exists()
+    {
+        $languageLine = $this->createLanguageLine('group', 'new', ['en' => 'English']);
+        $this->assertEquals('English', $languageLine->getTranslation('es'));
+    }
+
+    /** @test */
+    public function dont_return_arrays_if_was_set()
+    {
+        $value = [
+            'max' => 'Maximo',
+            'min' => 'Minimo'
+        ];
+        $languageLine = $this->createLanguageLine('validation', 'attributes', ['es' => $value]);
+        $this->assertEquals('', $languageLine->getTranslation('es'));
+    }
 }


### PR DESCRIPTION
Right now when is tried to access to a not existed translation an exception is throwed

```
$languageLine = $this->createLanguageLine('group', 'new', ['nl' => 'nederlands']);
$languageLine->getTranslation('en');
```

This is an example of code that would throw an exception.

With this pull request the package will be able to return an empty string instead of the error.