### PR TITLE
Fix for non-flushed cache

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -87,6 +87,10 @@ class LanguageLine extends Model
 
     protected function getTranslatedLocales(): array
     {
-        return array_keys($this->text);
+        $original = [];
+        if(is_string($this->getOriginal('text'))){
+            $original = json_decode($this->getOriginal('text'), true) ?? [];
+        }
+        return array_keys($this->text + $original);
     }
 }

--- a/tests/LanguageLineTest.php
+++ b/tests/LanguageLineTest.php
@@ -50,4 +50,14 @@ class LanguageLineTest extends TestCase
         $this->assertEquals('English', $languageLine->getTranslation('es'));
     }
 
+    /** @test */
+    public function get_correct_translations_from_cache()
+    {
+        $languageLine = $this->createLanguageLine('group', 'key', ['cr' => 'creole', 'br' => 'barbados']);
+        $this->assertContains('creole', $languageLine->getTranslationsForGroup('cr', 'group'));
+        $languageLine->text = ['br' => 'barbados']; // no more creole
+        $languageLine->save();
+        $this->assertNotContains('creole', $languageLine->getTranslationsForGroup('cr', 'group'));
+    }
+
 }


### PR DESCRIPTION
Caching translation keys has a problem - the code will flush cache for all "TranslatedLocales" of a Language Line. But if you remove a translation, then TranslatedLocales don't include the locale that you're deleting. My fix is kind of ugly, so you might want to do it some other way.