### PR TITLE
Lumen compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![StyleCI](https://styleci.io/repos/70038687/shield?branch=master)](https://styleci.io/repos/70038687)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-translation-loader.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-translation-loader)
 
-In a vanilla Laravel installation you can use [language files](https://laravel.com/docs/5.6/localization) to localize your app. This package will enable the translations to be stored in the database. You can still use all the features of [the `trans` function](https://laravel.com/docs/5.6/localization#retrieving-translation-strings) you know and love.
+In a vanilla Laravel or Lumen installation you can use [language files](https://laravel.com/docs/5.6/localization) to localize your app. This package will enable the translations to be stored in the database. You can still use all the features of [the `trans` function](https://laravel.com/docs/5.6/localization#retrieving-translation-strings) you know and love.
 
 ```php
 trans('messages.welcome', ['name' => 'dayle']);
@@ -28,7 +28,7 @@ You can install the package via composer:
 composer require spatie/laravel-translation-loader
 ```
 
-In `config/app.php` you should replace Laravel's translation service provider
+In `config/app.php` (Laravel) or `bootstrap/app.php` (Lumen) you should replace Laravel's translation service provider
 
 ```php
 Illuminate\Translation\TranslationServiceProvider::class,
@@ -79,6 +79,8 @@ return [
 
 ];
 ```
+
+> **Note:** publishing assets doesn't work out of the box in Lumen. Instead you have to copy the files from the repo.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "laravel/framework": "~5.5.0|~5.6.0|~5.7.0"
+        "illuminate/translation": "~5.5.0|~5.6.0|~5.7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3|^7.0",

--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -22,7 +22,7 @@ class TranslationServiceProvider extends IlluminateTranslationServiceProvider
      */
     public function boot()
     {
-        if ($this->app->runningInConsole()) {
+        if ($this->app->runningInConsole() && !str_contains($this->app->version(), 'Lumen')) {
             $this->publishes([
                 __DIR__.'/../config/translation-loader.php' => config_path('translation-loader.php'),
             ], 'config');


### PR DESCRIPTION
These changes enable the package to be used with the [Lumen framework](https://lumen.laravel.com). They're required because the `config_path` helper and `artisan publish` command is not available there. I've also changed the dependency from `laravel/framework` to the more specific `illuminate/translation` package in order to support both Laravel and Lumen.