### PR TITLE
prevent the new registerLoader() to run if the language_lines table d…

### DIFF
--- a/src/TranslationServiceProvider.php
+++ b/src/TranslationServiceProvider.php
@@ -4,6 +4,7 @@ namespace Spatie\TranslationLoader;
 
 use Illuminate\Translation\FileLoader;
 use Illuminate\Translation\TranslationServiceProvider as IlluminateTranslationServiceProvider;
+use Illuminate\Support\Facades\Schema;
 
 class TranslationServiceProvider extends IlluminateTranslationServiceProvider
 {
@@ -44,10 +45,18 @@ class TranslationServiceProvider extends IlluminateTranslationServiceProvider
      */
     protected function registerLoader()
     {
-        $this->app->singleton('translation.loader', function ($app) {
-            $class = config('translation-loader.translation_manager');
+        if (Schema::hasTable('language_lines')) {
+            $this->app->singleton('translation.loader', function ($app) {
+                $class = config('translation-loader.translation_manager');
 
-            return new $class($app['files'], $app['path.lang']);
-        });
+                return new $class($app['files'], $app['path.lang']);
+            });
+        } else {
+            
+            $this->app->singleton('translation.loader', function ($app) {
+                return new FileLoader($app['files'], $app['path.lang']);
+            });
+
+        }
     }
 }


### PR DESCRIPTION
So, I've created my first pull request (ever). 

It will fix the issue I reported as following. 

The new `registerLoader()` functions will be loaded in case the 'language_lines' table exists. If not, the standard Laravel `registerLoader()` functions will run.