### PR TITLE
Add locale condition

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -33,6 +33,7 @@ class LanguageLine extends Model
         return Cache::rememberForever(static::getCacheKey($group, $locale), function () use ($group, $locale) {
             return static::query()
                 ->where('group', $group)
+                ->whereNotNull('text->' . $locale)
                 ->get()
                 ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
                     $translation = $languageLine->getTranslation($locale);


### PR DESCRIPTION
Hi,

I think we could add the locale in the condition of the static function LanguageLine::getTranslationsForGroup.

Imagine you have french locale in the regular translation file, and english locale on database.

Curently if you are on the french version, you will see the english translation, because the function considers the line exists.

With this condition, it will check the wanted locale is existing.

Is ok for you ?