### PR TITLE
adds ability to save & load json translations that have dot in their key

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -34,9 +34,15 @@ class LanguageLine extends Model
             return static::query()
                 ->where('group', $group)
                 ->get()
-                ->reduce(function ($lines, LanguageLine $languageLine) use ($locale) {
+                ->reduce(function ($lines, LanguageLine $languageLine) use ($group, $locale) {
                     $translation = $languageLine->getTranslation($locale);
-                    if ($translation !== null) {
+
+                    // make flat array when returning json translations
+                    if ($translation !== null && $group === '*') {
+                        $lines[$languageLine->key] = $translation;
+                    }
+                    // make nesetd array when returning normal translations
+                    elseif($translation !== null && $group !== '*'){
                         array_set($lines, $languageLine->key, $translation);
                     }
 

--- a/tests/TransJsonTest.php
+++ b/tests/TransJsonTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Spatie\TranslationLoader\Test;
+
+use Illuminate\Support\Arr;
+
+class TransJsonTest extends TestCase
+{
+    const TERM1 = 'file not found';
+    const TERM1_EN = 'File not found in en';
+    const TERM1_NL = 'File not found in nl';
+    const TERM1_EN_DB = 'File not found in en from db';
+    const TERM1_NL_DB = 'File not found in nl from db';
+    const TERM2 = 'file not found. it might be in trash.';
+    const TERM2_EN = 'File not found in en. It might be in trash.';
+    const TERM2_NL = 'File not found in nl. It might be in trash.';
+    const TERM2_EN_DB = 'File not found in en from db. It might be in trash.';
+    const TERM2_NL_DB = 'File not found in nl from db. It might be in trash.';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /** @test */
+    public function it_can_get_translations_for_language_files()
+    {
+        $this->assertEquals(self::TERM1_EN, __(self::TERM1));
+        $this->assertEquals(self::TERM2_EN, __(self::TERM2));
+    }
+
+    /** @test */
+    public function it_can_get_translations_for_language_files_for_the_current_locale()
+    {
+        app()->setLocale('nl');
+
+        $this->assertEquals(self::TERM1_NL, __(self::TERM1));
+        $this->assertEquals(self::TERM2_NL, __(self::TERM2));
+    }
+
+    /** @test */
+    public function by_default_it_will_prefer_a_db_translation_over_a_file_translation()
+    {
+        $this->createLanguageLine('*', self::TERM1, ['en' => self::TERM1_EN_DB]);
+        $this->createLanguageLine('*', self::TERM2, ['en' => self::TERM2_EN_DB]);
+
+        $this->assertEquals(self::TERM1_EN_DB, __(self::TERM1));
+        $this->assertEquals(self::TERM2_EN_DB, __(self::TERM2));
+    }
+
+    /** @test */
+    public function it_will_default_to_fallback_if_locale_is_missing()
+    {
+        app()->setLocale('de');
+        $this->createLanguageLine('*', self::TERM1, ['en' => self::TERM1_EN_DB]);
+
+        $this->assertEquals(self::TERM1_EN_DB, __(self::TERM1));
+    }
+}

--- a/tests/fixtures/lang/en.json
+++ b/tests/fixtures/lang/en.json
@@ -1,0 +1,4 @@
+{
+    "file not found":                        "File not found in en",
+    "file not found. it might be in trash.": "File not found in en. It might be in trash."
+}

--- a/tests/fixtures/lang/nl.json
+++ b/tests/fixtures/lang/nl.json
@@ -1,0 +1,4 @@
+{
+    "file not found":                        "File not found in nl",
+    "file not found. it might be in trash.": "File not found in nl. It might be in trash."
+}


### PR DESCRIPTION
This is a patch to make dot-included translation keys work in this package. Currently it is possible to save & retrieve json translations by setting `'group' => '*'` when creating a LanguageLine & retrieving it by Laravel's `__` helper function. but if the key have dot character included in its key, it will fail to return the value.

### Expected Behavior
It is expected to return json translations normally when using `__($key)` method, even if they have dots inside their key (happens a lot).

### Actual Behavior 
Currently when using `__($key)` method to get some translation with dots inside its key, it will return the key itself or translations that exist inside json files ( not database one). for example assuming we have translation with key `file not found. it might be in trash.` saved to database in application's locale, calling `__('file not found. it might be in trash.')` will result the key it self. 