### PR TITLE
Do not hardcode table name as it can be changed in config

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -19,8 +19,11 @@ class TranslationLoaderManager extends FileLoader
      */
     public function load($locale, $group, $namespace = null): array
     {
-        if (! Schema::hasTable((new (config('translation-loader.model')))->getTable())) {
-            return parent::load($locale, $group, $namespace);
+        $modelClass = new (config('translation-loader.model'));
+        if (is_a(new $modelClass, LanguageLine::class)) {
+            if (! Schema::hasTable($modelClass->getTable())) {
+                return parent::load($locale, $group, $namespace);
+            }
         }
 
         $fileTranslations = parent::load($locale, $group, $namespace);

--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -19,9 +19,10 @@ class TranslationLoaderManager extends FileLoader
      */
     public function load($locale, $group, $namespace = null): array
     {
-        $modelClass = new (config('translation-loader.model'));
-        if (is_a(new $modelClass, LanguageLine::class)) {
-            if (! Schema::hasTable($modelClass->getTable())) {
+        $modelClass = config('translation-loader.model');
+        $model = new $modelClass;
+        if (is_a($model, LanguageLine::class)) {
+            if (! Schema::hasTable($model->getTable())) {
                 return parent::load($locale, $group, $namespace);
             }
         }

--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -19,7 +19,7 @@ class TranslationLoaderManager extends FileLoader
      */
     public function load($locale, $group, $namespace = null): array
     {
-        if (!Schema::hasTable('language_lines')) {
+        if (! Schema::hasTable((new (config('translation-loader.model')))->getTable())) {
             return parent::load($locale, $group, $namespace);
         }
 

--- a/tests/TranslationLoaders/DbTest.php
+++ b/tests/TranslationLoaders/DbTest.php
@@ -102,9 +102,9 @@ class DbTest extends TestCase
     public function it_can_work_with_a_custom_model()
     {
         $alternativeModel = new class extends LanguageLine {
+            protected $table = 'language_lines';
             public static function getTranslationsForGroup(string $locale, string $group): array
             {
-                protected $table = 'language_lines';
                 return ['key' => 'alternative class'];
             }
         };

--- a/tests/TranslationLoaders/DbTest.php
+++ b/tests/TranslationLoaders/DbTest.php
@@ -104,6 +104,7 @@ class DbTest extends TestCase
         $alternativeModel = new class extends LanguageLine {
             public static function getTranslationsForGroup(string $locale, string $group): array
             {
+                protected $table = 'language_lines';
                 return ['key' => 'alternative class'];
             }
         };


### PR DESCRIPTION
This is an addition to https://github.com/spatie/laravel-translation-loader/pull/141
As discussed, I recommend not hard-coding ```language_lines```table name.