### PR TITLE
Prevent unnecessary query call when model exists

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\TranslationLoader;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Translation\FileLoader;
 use Illuminate\Support\Facades\Schema;
 use Spatie\TranslationLoader\TranslationLoaders\TranslationLoader;
@@ -19,23 +20,27 @@ class TranslationLoaderManager extends FileLoader
      */
     public function load($locale, $group, $namespace = null): array
     {
-        $modelClass = config('translation-loader.model');
-        $model = new $modelClass;
-        if (is_a($model, LanguageLine::class)) {
-            if (! Schema::hasTable($model->getTable())) {
-                return parent::load($locale, $group, $namespace);
+        try {
+            $fileTranslations = parent::load($locale, $group, $namespace);
+
+            if (!is_null($namespace) && $namespace !== '*') {
+                return $fileTranslations;
             }
+
+            $loaderTranslations = $this->getTranslationsForTranslationLoaders($locale, $group, $namespace);
+
+            return array_replace_recursive($fileTranslations, $loaderTranslations);
+        } catch (QueryException $e) {
+            $modelClass = config('translation-loader.model');
+            $model = new $modelClass;
+            if (is_a($model, LanguageLine::class)) {
+                if (! Schema::hasTable($model->getTable())) {
+                    return parent::load($locale, $group, $namespace);
+                }
+            }
+
+            throw $e;
         }
-
-        $fileTranslations = parent::load($locale, $group, $namespace);
-
-        if (! is_null($namespace) && $namespace !== '*') {
-            return $fileTranslations;
-        }
-
-        $loaderTranslations = $this->getTranslationsForTranslationLoaders($locale, $group, $namespace);
-
-        return array_replace_recursive($fileTranslations, $loaderTranslations);
     }
 
     protected function getTranslationsForTranslationLoaders(


### PR DESCRIPTION
The changes in #141 #142 caused lots of duplicate query calls for me:
<img width="944" alt="image" src="https://user-images.githubusercontent.com/20278756/155337911-c5cc7527-8341-4633-ad7e-606f649454ba.png">

This fixes it by moving `hasTable` query call added in #141 #142  to a catch `QueryException` so that it only runs when it actually needs to.  

@AlexisSerneels @haringsrob Feel free to discuss
