### PR TITLE
Avoid DB queries when there is no DB connection

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -34,7 +34,12 @@ class TranslationLoaderManager extends FileLoader
             $modelClass = config('translation-loader.model');
             $model = new $modelClass;
             if (is_a($model, LanguageLine::class)) {
-                if (! Schema::hasTable($model->getTable())) {
+                try {
+                    DB::connection()->getPdo();
+                    if (! Schema::hasTable($model->getTable())) {
+                        return parent::load($locale, $group, $namespace);
+                    }
+                } catch (\Exception $pdoException) {
                     return parent::load($locale, $group, $namespace);
                 }
             }

--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -4,6 +4,7 @@ namespace Spatie\TranslationLoader;
 
 use Illuminate\Database\QueryException;
 use Illuminate\Translation\FileLoader;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Spatie\TranslationLoader\TranslationLoaders\TranslationLoader;
 
@@ -35,7 +36,7 @@ class TranslationLoaderManager extends FileLoader
             $model = new $modelClass;
             if (is_a($model, LanguageLine::class)) {
                 try {
-                    \DB::connection()->getPdo();
+                    DB::connection()->getPdo();
                     if (! Schema::hasTable($model->getTable())) {
                         return parent::load($locale, $group, $namespace);
                     }

--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -35,7 +35,7 @@ class TranslationLoaderManager extends FileLoader
             $model = new $modelClass;
             if (is_a($model, LanguageLine::class)) {
                 try {
-                    DB::connection()->getPdo();
+                    \DB::connection()->getPdo();
                     if (! Schema::hasTable($model->getTable())) {
                         return parent::load($locale, $group, $namespace);
                     }


### PR DESCRIPTION
This modification is proposed to offer a solution to the problem exposed in the discussion #145 

Before checking the existence of the translation table, the code checks if there is a DB connection.

Best regards,