### PR TITLE
Addressing the Challenge of Persistent Group Values After Cache Forge…

### DIFF
--- a/src/LanguageLine.php
+++ b/src/LanguageLine.php
@@ -88,6 +88,7 @@ class LanguageLine extends Model
     public function flushGroupCache()
     {
         foreach ($this->getTranslatedLocales() as $locale) {
+            Cache::forget(static::getCacheKey($this->getOriginal('group'), $locale));
             Cache::forget(static::getCacheKey($this->group, $locale));
         }
     }


### PR DESCRIPTION
I have identified an issue with the package, specifically related to the 'group' attribute. When modifying the text, the package attempts to clear the cache using the existing group name and key. It functions correctly when the text changes, but not when the group name of the translation record is modified. In this case, the package attempts to forget the cache using the new group key, but fails to forget the cache associated with the old group.

This issue may arise in situations where a translation is moved to a new group, but the translation still exists in the previous group.