### PR TITLE
Correct nullable type

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -46,7 +46,7 @@ class TranslationLoaderManager extends FileLoader
     protected function getTranslationsForTranslationLoaders(
         string $locale,
         string $group,
-        string $namespace = null
+        ?string $namespace = null
     ): array {
         return collect(config('translation-loader.translation_loaders'))
             ->map(function (string $className) {


### PR DESCRIPTION
Implicitly nullable parameter types are now deprecated in PHP 8.4

```
Spatie\TranslationLoader\TranslationLoaderManager::getTranslationsForTranslationLoaders(): Implicitly marking parameter $namespace as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/spatie/laravel-translation-loader/src/TranslationLoaderManager.php on line 46
```